### PR TITLE
Update the 250 XP Increase Item in the Store

### DIFF
--- a/src/main/java/com/cominatyou/store/items/MediumXPIncrease.java
+++ b/src/main/java/com/cominatyou/store/items/MediumXPIncrease.java
@@ -18,9 +18,9 @@ public class MediumXPIncrease extends StoreItem {
 
         final int currentXP = user.getXP();
         user.decrementKey("tokens", getPrice());
-        user.incrementKey("xp", 100);
+        user.incrementKey("xp", 250);
 
-        final EmbedBuilder embed = SuccessfulPurchaseEmbed.create(interaction.getUser(), "You've received an extra 100 XP.");
+        final EmbedBuilder embed = SuccessfulPurchaseEmbed.create(interaction.getUser(), "You've received an extra 250 XP.");
 
         interaction.getMessage().createUpdater()
             .removeAllComponents()


### PR DESCRIPTION
## Description
At the time of writing, it seems to be that the "250 XP" item in the Hildabot store seems to be broken. Rather than giving the user 250 XP for their 300 tokens, the bot only gives the user 100 XP.

I have yet to fully use the entirety of Hildabot's store, but this does not seem right, as previous commits affirm that the XP given should be 250, not 100.

## Proposed changes
- Fix the "250 XP" item in the Hildabot store where it describes it will give the user 250 XP but the user only receives 100