### PR TITLE
Fix a User's Displayed Username in a Welcome Message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.cominatyou</groupId>
   <artifactId>hildabot</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.3</version>
 
   <name>hildabot</name>
   <url>http://www.example.com</url>

--- a/src/main/java/com/cominatyou/eventhandlers/memberevents/MemberPassGate.java
+++ b/src/main/java/com/cominatyou/eventhandlers/memberevents/MemberPassGate.java
@@ -26,7 +26,7 @@ public class MemberPassGate {
         final String welcomeMessage = String.format("**#%s - Welcome to Hildacord,** %s**!** %s\n\nHildacord is a great place for everyone from all around the world to come around a show that they all love: Hilda!", ThousandsFormat.format(memberCount), event.getUser().getMentionTag(), greeting);
 
         EmbedBuilder embed = new EmbedBuilder()
-            .setAuthor(event.getUser().getDiscriminatedName(), null, event.getUser().getAvatar())
+            .setAuthor(event.getUser().getDisplayName(event.getServer()), null, event.getUser().getAvatar())
             .addField("New to Discord?", "Don't worry! The folks at Discord HQ have got an [article](https://support.discord.com/hc/en-us/articles/360045138571-Beginner-s-Guide-to-Discord) to help you get up to speed!")
             .addInlineField("To get started, please read:", "- [Rules](https://discord.com/channels/492572315138392064/657825719522689045)\n- [Server Info](https://discord.com/channels/492572315138392064/657718082831384606)\n- [Plural Info](https://discord.com/channels/492572315138392064/787521898170810368)")
             .addInlineField("Channels to check out!", "- [Show Discussion](https://discord.com/channels/492572315138392064/492573040027369483)\n- [Movie Discussion](https://discord.com/channels/492572315138392064/498574984294301696)\n- [Fanart](https://discord.com/channels/492572315138392064/492580873628286976)")

--- a/src/main/java/com/cominatyou/util/versioning/Version.java
+++ b/src/main/java/com/cominatyou/util/versioning/Version.java
@@ -1,7 +1,7 @@
 package com.cominatyou.util.versioning;
 
 public class Version {
-    public static final String VERSION = "2.2.2";
-    public static final String BUILD_NUMBER = "11C021";
+    public static final String VERSION = "2.2.3";
+    public static final String BUILD_NUMBER = "11C022";
     public static final String VERSION_STRING = String.format("%s (%s)", VERSION, BUILD_NUMBER);
 }


### PR DESCRIPTION
## Description
Although a very minor issue, when the bot has detected a new user has passed the gates, it uses the `getDiscriminatedName` function to retrieve their username, which is now obsoleted thanks to Discord's recent changes with usernames.

It would be better to use the `getDisplayName` function to rather use Display Names to display in the welcome message, since it's what Discord wants to use and it's visually more appealing.

## Proposed Changes
- Use the `getDisplayName` function to use the User's Display Name instead of their username tied with an unappealing `#0` at the end.

(btw it might be strange to ask but is there any else i can help work on?)